### PR TITLE
Fix filename and bump memory (and CPU) allocation

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -53,7 +53,7 @@ Resources:
           Stage: !Ref Stage
       Description: Validates fulfilment information for a given subscription name
       Handler: com.gu.fulfilmentLookup.Lambda::handler
-      MemorySize: 512
+      MemorySize: 1536
       Role:
           Fn::GetAtt:
           - FulfilmentExecutionRole

--- a/src/main/scala/com/gu/fulfilmentLookup/Lambda.scala
+++ b/src/main/scala/com/gu/fulfilmentLookup/Lambda.scala
@@ -84,7 +84,7 @@ trait FulfilmentLookupLambda extends Logging {
     val dayOfWeek = date.getDayOfWeek.toString.toLowerCase.capitalize
     val dateFormatter = DateTimeFormatter.ofPattern("dd_MM_YYYY")
     val sfFileFormattedDate = date.format(dateFormatter)
-    s"HOME_DELIVERY_${dayOfWeek}${sfFileFormattedDate}.csv"
+    s"HOME_DELIVERY_${dayOfWeek}_${sfFileFormattedDate}.csv"
   }
 
   //This is slightly horrible, but is required as it seems the response body


### PR DESCRIPTION
This PR attempts to fix 2 production issues that I've noticed since last working on this:

1. The Salesforce filename has been changed recently and this has broken the (admittedly rather fragile) lookup. 
2. I'm seeing fairly regular timeouts in subs-frontend when this endpoint is called. As CPU and memory allocation are linked in the lambda environment, I'd like to try increasing this limit as a first step to eliminating these timeouts.

For 1, longer term we need to do something safer than relying on an exact string, but this is the shortest path to getting up and running again for now.

For 2, I suspect that these issues are largely due to 'cold starts', so if this change is insufficient I'll need to investigate techniques for keeping this lambda warm (or have a more significant re-think about the approach).

cc @paulbrown1982 @pvighi @johnduffell 