### PR TITLE
Raise Salesforce case after performing a lookup

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,10 +27,12 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.1.0",
   "com.amazonaws" % "aws-lambda-java-log4j" % "1.0.0",
   "com.amazonaws" % "aws-java-sdk-s3" % "1.11.163",
-  "log4j" % "log4j" % "1.2.17",
   "com.github.melrief" %% "purecsv" % "0.0.9",
+  "com.squareup.okhttp3" % "okhttp" % "3.4.1",
   "com.typesafe.play" %% "play-json" % "2.6.2",
+  "log4j" % "log4j" % "1.2.17",
   "org.scalatest" %% "scalatest" % "3.0.1" % "test",
+  "org.scalaz" % "scalaz-core_2.12" % "7.2.14",
   "org.mockito" % "mockito-core" % "1.9.5" % "test"
 )
 

--- a/src/main/scala/com/gu/fulfilmentLookup/Config.scala
+++ b/src/main/scala/com/gu/fulfilmentLookup/Config.scala
@@ -4,8 +4,20 @@ import java.lang.System.getenv
 
 trait Config {
   def stage: String
+  def salesforceUrl: String
+  def salesforceClientId: String
+  def salesforceClientSecret: String
+  def salesforceUsername: String
+  def salesforcePassword: String
+  def salesforceToken: String
 }
 
 object EnvConfig extends Config {
   override def stage: String = getenv("Stage")
+  override val salesforceUrl: String = getenv("sfUrl")
+  override val salesforceClientId: String = getenv("sfClientId")
+  override val salesforceClientSecret: String = getenv("sfClientSecret")
+  override val salesforceUsername: String = getenv("sfUser")
+  override val salesforcePassword: String = getenv("sfPass")
+  override val salesforceToken: String = getenv("sfToken")
 }

--- a/src/main/scala/com/gu/fulfilmentLookup/RequestModels.scala
+++ b/src/main/scala/com/gu/fulfilmentLookup/RequestModels.scala
@@ -2,14 +2,15 @@ package com.gu.fulfilmentLookup
 
 import java.time.LocalDate
 import play.api.libs.functional.syntax._
-import play.api.libs.json.{ JsPath, Json, Reads }
+import play.api.libs.json.{ JsPath, Reads }
 
-case class LookupRequest(subscriptionName: String, date: LocalDate)
+case class LookupRequest(subscriptionName: String, sfContactId: String, date: LocalDate)
 
 object LookupRequest {
 
   implicit val lookupRequestReads: Reads[LookupRequest] = (
     (JsPath \ "subscriptionName").read[String] and
+    (JsPath \ "sfContactId").read[String] and
     (JsPath \ "issueDate").read[LocalDate]
   )(LookupRequest.apply _)
 

--- a/src/main/scala/com/gu/fulfilmentLookup/SalesforceCaseService.scala
+++ b/src/main/scala/com/gu/fulfilmentLookup/SalesforceCaseService.scala
@@ -1,0 +1,81 @@
+package com.gu.fulfilmentLookup
+
+import java.util.concurrent.TimeUnit
+import okhttp3._
+import play.api.libs.json.{ JsPath, JsSuccess, Json, Reads }
+import play.api.libs.functional.syntax._
+import scalaz.{ -\/, \/, \/- }
+
+case class SalesforceAuth(accessToken: String, instanceUrl: String)
+
+object SalesforceAuth {
+
+  implicit val salesforceAuthReads: Reads[SalesforceAuth] = (
+    (JsPath \ "access_token").read[String] and
+    (JsPath \ "instance_url").read[String]
+  )(SalesforceAuth.apply _)
+
+}
+
+trait CaseService {
+  def authenticate(config: Config): String \/ SalesforceAuth
+  def raiseCase(config: Config, lookupRequest: LookupRequest, lookupResponseBody: LookupResponseBody): String \/ Boolean
+}
+
+object SalesforceCaseService extends CaseService with Logging {
+
+  val restClient = new OkHttpClient().newBuilder()
+    .readTimeout(15, TimeUnit.SECONDS)
+    .build()
+
+  def requestBuilder(config: Config, route: String): Request.Builder = {
+    new Request.Builder()
+      .url(s"${config.salesforceUrl}/$route")
+  }
+
+  def withSfAuth(requestBuilder: Request.Builder, salesforceAuth: SalesforceAuth): Request.Builder = {
+    requestBuilder.addHeader("Authorization", s"Bearer ${salesforceAuth.accessToken}")
+  }
+
+  override def authenticate(config: Config): String \/ SalesforceAuth = {
+    val builder = requestBuilder(config, "/services/oauth2/token")
+    val formBody = new FormBody.Builder()
+      .add("client_id", config.salesforceClientId)
+      .add("client_secret", config.salesforceClientSecret)
+      .add("username", config.salesforceUsername)
+      .add("password", config.salesforcePassword + config.salesforceToken)
+      .add("grant_type", "password")
+      .build()
+    val request = builder.post(formBody).build()
+    logger.info(s"Attempting to perform Salesforce Authentication")
+    val response = restClient.newCall(request).execute()
+    val responseBody = Json.parse(response.body().string())
+    responseBody.validate[SalesforceAuth] match {
+      case JsSuccess(result, _) =>
+        logger.info(s"Successful Salesforce authentication.")
+        \/-(result)
+      case _ =>
+        -\/(s"Failed to authenticate with Salesforce | body was: ${responseBody.toString}")
+    }
+  }
+
+  override def raiseCase(config: Config, lookupRequest: LookupRequest, lookupResponseBody: LookupResponseBody): String \/ Boolean = {
+    val salesforceAuth = authenticate(config)
+    salesforceAuth.flatMap { auth =>
+      val builderWithAuth = withSfAuth(requestBuilder(config, "sobjects/Case/"), auth)
+      val bodyString = Json.obj(
+        "ContactId" -> lookupRequest.sfContactId,
+        "Reason" -> "Non-delivery",
+        "Status" -> "New",
+        "Origin" -> "subscriptions",
+        "Subject" -> s"Non-delivery | Paper Date: ${lookupRequest.date}",
+        "Description" -> s"=== Debug Information === \n ${lookupResponseBody}"
+      ).toString()
+      val request = builderWithAuth.post(RequestBody.create(MediaType.parse("application/json"), bodyString)).build()
+      logger.info(s"Attempting to raise case in Salesforce for sfContactId: ${lookupRequest.sfContactId}")
+      val response = restClient.newCall(request).execute()
+      if (response.isSuccessful) \/-(true) else -\/(s"Failed to raise Salesforce case for sfContactId: ${lookupRequest.sfContactId}")
+    }
+  }
+
+}

--- a/src/main/scala/com/gu/fulfilmentLookup/SalesforceCaseService.scala
+++ b/src/main/scala/com/gu/fulfilmentLookup/SalesforceCaseService.scala
@@ -81,11 +81,11 @@ object SalesforceCaseService extends CaseService with Logging {
       val bodyString = Json.obj(
         "ContactId" -> lookupRequest.sfContactId,
         "Status" -> "New",
-        "Origin" -> "Home Delivery",
+        "Origin" -> "FulfilmentLookupAPI",
         "Product__c" -> "Home Delivery",
         "Journey__c" -> "CS - Home Delivery Support", // Case Type
         "Case_Closure_Reason__c" -> "No Delivery", // Sub-Category
-        "Subject" -> s"Delivery Issue | Paper Date: ${lookupRequest.date}",
+        "Subject" -> s"Delivery Problem | Paper Date: ${lookupRequest.date}",
         "Description" -> s"$debugInfo"
       ).toString()
       val request = builderWithAuth.post(RequestBody.create(MediaType.parse("application/json"), bodyString)).build()

--- a/src/main/scala/com/gu/fulfilmentLookup/SalesforceCaseService.scala
+++ b/src/main/scala/com/gu/fulfilmentLookup/SalesforceCaseService.scala
@@ -80,10 +80,12 @@ object SalesforceCaseService extends CaseService with Logging {
       val debugInfo = description(lookupResponseBody)
       val bodyString = Json.obj(
         "ContactId" -> lookupRequest.sfContactId,
-        "Reason" -> "Non-delivery",
         "Status" -> "New",
-        "Origin" -> "subscriptions",
-        "Subject" -> s"Non-delivery | Paper Date: ${lookupRequest.date}",
+        "Origin" -> "Home Delivery",
+        "Product__c" -> "Home Delivery",
+        "Journey__c" -> "CS - Home Delivery Support", // Case Type
+        "Case_Closure_Reason__c" -> "No Delivery", // Sub-Category
+        "Subject" -> s"Delivery Issue | Paper Date: ${lookupRequest.date}",
         "Description" -> s"$debugInfo"
       ).toString()
       val request = builderWithAuth.post(RequestBody.create(MediaType.parse("application/json"), bodyString)).build()

--- a/src/test/resources/fulfilmentLookup/validRequestSubInFile.json
+++ b/src/test/resources/fulfilmentLookup/validRequestSubInFile.json
@@ -49,6 +49,6 @@
     "httpMethod": "POST",
     "apiId": "someApiId"
   },
-  "body": "{\n \"subscriptionName\":\"A-S12345\",\n    \"issueDate\": \"2017-07-21\"\n }",
+  "body": "{\n \"subscriptionName\":\"A-S12345\",\n  \"sfContactId\":\"sf12345\",\n   \"issueDate\": \"2017-07-21\"\n }",
   "isBase64Encoded": false
 }

--- a/src/test/resources/fulfilmentLookup/validRequestSubNotInFile.json
+++ b/src/test/resources/fulfilmentLookup/validRequestSubNotInFile.json
@@ -49,6 +49,6 @@
     "httpMethod": "POST",
     "apiId": "someApiId"
   },
-  "body": "{\n \"subscriptionName\":\"A-S67815\",\n    \"issueDate\": \"2017-07-21\"\n }",
+  "body": "{\n \"subscriptionName\":\"A-S67815\",\n  \"sfContactId\":\"sf67891\",\n  \"issueDate\": \"2017-07-21\"\n }",
   "isBase64Encoded": false
 }

--- a/src/test/scala/com/gu/fulfilmentLookup/AwsS3ClientTest.scala
+++ b/src/test/scala/com/gu/fulfilmentLookup/AwsS3ClientTest.scala
@@ -2,9 +2,7 @@ package com.gu.fulfilmentLookup
 
 import org.scalatest.FlatSpec
 import org.scalatest.mockito.MockitoSugar
-
 import scala.io.Source
-import scala.util.Success
 
 class AwsS3ClientTest extends FlatSpec with MockitoSugar with Logging {
 

--- a/src/test/scala/com/gu/fulfilmentLookup/LambdaTest.scala
+++ b/src/test/scala/com/gu/fulfilmentLookup/LambdaTest.scala
@@ -98,7 +98,7 @@ class LambdaTest extends FlatSpec with MockitoSugar {
   }
 
   "lookUp" should "return an error if we fail to raise a case in Salesforce" in {
-    when(fakeS3Client.getDeliveryRowsFromS3("fulfilment-output-test", "CODE/salesforce_output/", "HOME_DELIVERY_Friday21_07_2017.csv")).thenReturn(Success(deliveryRows))
+    when(fakeS3Client.getDeliveryRowsFromS3("fulfilment-output-test", "CODE/salesforce_output/", "HOME_DELIVERY_Friday_21_07_2017.csv")).thenReturn(Success(deliveryRows))
     when(fakeSfCaseService.raiseCase(fakeConfig, lookupRequestA, presentLookupResponse)).thenReturn(-\/("Failed to raise SF case"))
     assert(lambda.lookUp(lookupRequestA, new ByteArrayOutputStream) == LookupResponse(500, "Failed to raise SF case"))
   }

--- a/src/test/scala/com/gu/fulfilmentLookup/LambdaTest.scala
+++ b/src/test/scala/com/gu/fulfilmentLookup/LambdaTest.scala
@@ -7,19 +7,30 @@ import org.scalatest.FlatSpec
 import org.scalatest.mockito.MockitoSugar
 import org.mockito.Mockito._
 import org.scalatest.Matchers._
-
 import scala.util.{ Failure, Success }
+import scalaz.{ -\/, \/- }
 
 class LambdaTest extends FlatSpec with MockitoSugar {
 
   val fakeS3Client = mock[CsvClient]
 
+  val fakeSfCaseService = mock[CaseService]
+
+  val fakeSfAuth = SalesforceAuth("token123", "fakeUrl")
+
   val fakeConfig = new Config {
     override val stage = "CODE"
+    override val salesforceUrl = "sfUrl"
+    override val salesforceClientId = "sfClientId"
+    override val salesforceClientSecret = "sfClientSecret"
+    override val salesforceUsername = "sfUser"
+    override val salesforcePassword = "sfPass"
+    override val salesforceToken = "sfToken"
   }
 
   val lambda = new FulfilmentLookupLambda {
     override def s3Client: CsvClient = fakeS3Client
+    override def caseService: CaseService = fakeSfCaseService
     override def config: Config = fakeConfig
   }
 
@@ -46,8 +57,8 @@ class LambdaTest extends FlatSpec with MockitoSugar {
   val expectedAddress = "House 123, The Street, Islington, London, N1 9AG"
   val deliveryRows = List(fakeDeliveryRowB, fakeDeliveryRowA)
 
-  val lookupRequestA = LookupRequest("A-S12345", date)
-  val lookupRequestB = LookupRequest("A-S67815", date)
+  val lookupRequestA = LookupRequest("A-S12345", "sf12345", date)
+  val lookupRequestB = LookupRequest("A-S67815", "sf67891", date)
 
   val presentLookupResponse = LookupResponseBody("HOME_DELIVERY_Friday_21_07_2017.csv", true, Some(expectedAddress))
   val missingLookupResponse = LookupResponseBody("HOME_DELIVERY_Friday_21_07_2017.csv", false, None)
@@ -71,17 +82,25 @@ class LambdaTest extends FlatSpec with MockitoSugar {
 
   "lookUp" should "build a correct LookupResponse when a subscription is present" in {
     when(fakeS3Client.getDeliveryRowsFromS3("fulfilment-output-test", "CODE/salesforce_output/", "HOME_DELIVERY_Friday_21_07_2017.csv")).thenReturn(Success(deliveryRows))
+    when(fakeSfCaseService.raiseCase(fakeConfig, lookupRequestA, presentLookupResponse)).thenReturn(\/-(true))
     assert(lambda.lookUp(lookupRequestA, new ByteArrayOutputStream) == LookupResponse(200, lambda.responseBodyAsString(presentLookupResponse)))
   }
 
   "lookUp" should "build a correct LookupResponse when a subscription is missing" in {
     when(fakeS3Client.getDeliveryRowsFromS3("fulfilment-output-test", "CODE/salesforce_output/", "HOME_DELIVERY_Friday_21_07_2017.csv")).thenReturn(Success(deliveryRows))
+    when(fakeSfCaseService.raiseCase(fakeConfig, lookupRequestB, missingLookupResponse)).thenReturn(\/-(true))
     assert(lambda.lookUp(lookupRequestB, new ByteArrayOutputStream) == LookupResponse(200, lambda.responseBodyAsString(missingLookupResponse)))
   }
 
   "lookUp" should "return an error when there is a problem getting delivery rows from S3" in {
     when(fakeS3Client.getDeliveryRowsFromS3("fulfilment-output-test", "CODE/salesforce_output/", "HOME_DELIVERY_Friday_21_07_2017.csv")).thenReturn(Failure(new AmazonServiceException("Error from S3")))
     assert(lambda.lookUp(lookupRequestB, new ByteArrayOutputStream) == LookupResponse(500, "Failed to retrieve fulfilment records"))
+  }
+
+  "lookUp" should "return an error if we fail to raise a case in Salesforce" in {
+    when(fakeS3Client.getDeliveryRowsFromS3("fulfilment-output-test", "CODE/salesforce_output/", "HOME_DELIVERY_Friday21_07_2017.csv")).thenReturn(Success(deliveryRows))
+    when(fakeSfCaseService.raiseCase(fakeConfig, lookupRequestA, presentLookupResponse)).thenReturn(-\/("Failed to raise SF case"))
+    assert(lambda.lookUp(lookupRequestA, new ByteArrayOutputStream) == LookupResponse(500, "Failed to raise SF case"))
   }
 
   //Tests for complete Lambda processing
@@ -92,6 +111,7 @@ class LambdaTest extends FlatSpec with MockitoSugar {
     val inputStream = getClass.getResourceAsStream("/fulfilmentLookup/validRequestSubInFile.json")
     val outputStream = new ByteArrayOutputStream
     when(fakeS3Client.getDeliveryRowsFromS3("fulfilment-output-test", "CODE/salesforce_output/", "HOME_DELIVERY_Friday_21_07_2017.csv")).thenReturn(Success(deliveryRows))
+    when(fakeSfCaseService.raiseCase(fakeConfig, lookupRequestA, presentLookupResponse)).thenReturn(\/-(true))
     lambda.handler(inputStream, outputStream, null)
     val responseString = new String(outputStream.toByteArray(), "UTF-8")
     val expected =
@@ -103,6 +123,7 @@ class LambdaTest extends FlatSpec with MockitoSugar {
     val inputStream = getClass.getResourceAsStream("/fulfilmentLookup/validRequestSubNotInFile.json")
     val outputStream = new ByteArrayOutputStream
     when(fakeS3Client.getDeliveryRowsFromS3("fulfilment-output-test", "CODE/salesforce_output/", "HOME_DELIVERY_Friday_21_07_2017.csv")).thenReturn(Success(deliveryRows))
+    when(fakeSfCaseService.raiseCase(fakeConfig, lookupRequestB, missingLookupResponse)).thenReturn(\/-(true))
     lambda.handler(inputStream, outputStream, null)
     val responseString = new String(outputStream.toByteArray(), "UTF-8")
     val expected =


### PR DESCRIPTION
This PR adds logic to raise a Salesforce case after performing a fulfilment lookup. 

This should enable us to start tracking whether non-deliveries are due to fulfilment bugs or distribution problems. (I need to chat to Matt about the exact details of the case reason/categorisation, but hopefully this PR serves as a useful proof of concept).

It should also mean that we can resolve cases faster, as agents will be able to send fulfilment issues straight to us rather than wasting time raising a distribution check.

Here are some example cases in UAT:
Sub found: https://cs17.salesforce.com/500g000000GWUwB
Sub not found: https://cs17.salesforce.com/500g000000GWUwL