### PR TITLE
Use file from new pipeline

### DIFF
--- a/src/main/scala/com/gu/fulfilmentLookup/Lambda.scala
+++ b/src/main/scala/com/gu/fulfilmentLookup/Lambda.scala
@@ -57,7 +57,7 @@ trait FulfilmentLookupLambda extends Logging {
   // Main logic happens here
   def lookUp(config: Config, lookupRequest: LookupRequest, outputStream: OutputStream): LookupResponse = {
     val bucket = "fulfilment-output-test"
-    val subFolder = s"${stage}/salesforce_output/"
+    val subFolder = s"${stage}/uploaded/"
     val fileName = sfFilename(lookupRequest.date)
     val deliveryRows = csvClient.getDeliveryRowsFromS3(bucket, subFolder, fileName)
     deliveryRows match {

--- a/src/test/scala/com/gu/fulfilmentLookup/LambdaTest.scala
+++ b/src/test/scala/com/gu/fulfilmentLookup/LambdaTest.scala
@@ -84,24 +84,24 @@ class LambdaTest extends FlatSpec with MockitoSugar {
   }
 
   "lookUp" should "build a correct LookupResponse when a subscription is present" in {
-    when(fakeFulfilmentClient.getDeliveryRowsFromS3("fulfilment-output-test", "DEV/salesforce_output/", "HOME_DELIVERY_Friday_21_07_2017.csv")).thenReturn(Success(deliveryRows))
+    when(fakeFulfilmentClient.getDeliveryRowsFromS3("fulfilment-output-test", "DEV/uploaded/", "HOME_DELIVERY_Friday_21_07_2017.csv")).thenReturn(Success(deliveryRows))
     when(fakeSfCaseRaiser.open(fakeConfig, lookupRequestA, presentLookupResponse)).thenReturn(\/-(true))
     assert(lambda.lookUp(fakeConfig, lookupRequestA, new ByteArrayOutputStream) == LookupResponse(200, lambda.responseBodyAsString(presentLookupResponse)))
   }
 
   "lookUp" should "build a correct LookupResponse when a subscription is missing" in {
-    when(fakeFulfilmentClient.getDeliveryRowsFromS3("fulfilment-output-test", "DEV/salesforce_output/", "HOME_DELIVERY_Friday_21_07_2017.csv")).thenReturn(Success(deliveryRows))
+    when(fakeFulfilmentClient.getDeliveryRowsFromS3("fulfilment-output-test", "DEV/uploaded/", "HOME_DELIVERY_Friday_21_07_2017.csv")).thenReturn(Success(deliveryRows))
     when(fakeSfCaseRaiser.open(fakeConfig, lookupRequestB, missingLookupResponse)).thenReturn(\/-(true))
     assert(lambda.lookUp(fakeConfig, lookupRequestB, new ByteArrayOutputStream) == LookupResponse(200, lambda.responseBodyAsString(missingLookupResponse)))
   }
 
   "lookUp" should "return an error when there is a problem getting delivery rows from S3" in {
-    when(fakeFulfilmentClient.getDeliveryRowsFromS3("fulfilment-output-test", "DEV/salesforce_output/", "HOME_DELIVERY_Friday_21_07_2017.csv")).thenReturn(Failure(new AmazonServiceException("Error from S3")))
+    when(fakeFulfilmentClient.getDeliveryRowsFromS3("fulfilment-output-test", "DEV/uploaded/", "HOME_DELIVERY_Friday_21_07_2017.csv")).thenReturn(Failure(new AmazonServiceException("Error from S3")))
     assert(lambda.lookUp(fakeConfig, lookupRequestB, new ByteArrayOutputStream) == LookupResponse(500, "Failed to retrieve fulfilment records"))
   }
 
   "lookUp" should "return an error if we fail to raise a case in Salesforce" in {
-    when(fakeFulfilmentClient.getDeliveryRowsFromS3("fulfilment-output-test", "DEV/salesforce_output/", "HOME_DELIVERY_Friday_21_07_2017.csv")).thenReturn(Success(deliveryRows))
+    when(fakeFulfilmentClient.getDeliveryRowsFromS3("fulfilment-output-test", "DEV/uploaded/", "HOME_DELIVERY_Friday_21_07_2017.csv")).thenReturn(Success(deliveryRows))
     when(fakeSfCaseRaiser.open(fakeConfig, lookupRequestA, presentLookupResponse)).thenReturn(-\/("Failed to raise SF case"))
     assert(lambda.lookUp(fakeConfig, lookupRequestA, new ByteArrayOutputStream) == LookupResponse(500, "Failed to raise SF case"))
   }


### PR DESCRIPTION
Now that we're using https://github.com/guardian/fulfilment-lambdas to generate the files, we should be picking those up for debug purposes.

Note that this will need to be changed again when https://github.com/guardian/fulfilment-lambdas/pull/74 is merged.

cc @pvighi @paulbrown1982 