### PR TITLE
Fix date formatting

### DIFF
--- a/src/main/scala/com/gu/fulfilmentLookup/Lambda.scala
+++ b/src/main/scala/com/gu/fulfilmentLookup/Lambda.scala
@@ -100,7 +100,7 @@ trait FulfilmentLookupLambda extends Logging {
 
   def sfFilename(date: LocalDate): String = {
     val dayOfWeek = date.getDayOfWeek.toString.toLowerCase.capitalize
-    val dateFormatter = DateTimeFormatter.ofPattern("dd_MM_YYYY")
+    val dateFormatter = DateTimeFormatter.ofPattern("dd_MM_yyyy")
     val sfFileFormattedDate = date.format(dateFormatter)
     s"HOME_DELIVERY_${dayOfWeek}_${sfFileFormattedDate}.csv"
   }


### PR DESCRIPTION
Use year instead of week year when formatting dates:
https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html

Using the wrong case here worked fine 99% of the time, but it meant that we were incorrectly attempting to retrieve the 31st December **2018** file when lookups were performed for 2017-12-31.

Sound familiar @paulbrown1982 @davidpepper223?
