### PR TITLE
Remove PII from response

### DIFF
--- a/src/main/scala/com/gu/fulfilmentLookup/Lambda.scala
+++ b/src/main/scala/com/gu/fulfilmentLookup/Lambda.scala
@@ -66,16 +66,16 @@ trait FulfilmentLookupLambda extends Logging {
         val subNames = rows.map(row => row.subscriptionName)
         val subInFile = subNames.contains(lookupRequest.subscriptionName)
         val subIndex = subNames.indexOf(lookupRequest.subscriptionName)
-        val responseBody = LookupResponseBody(
+        val result = LookupResult(
           fileName,
           subInFile,
           populateAddressRecord(rows, subIndex)
         )
         logger.info(s"Performed successful lookup for ${lookupRequest.subscriptionName} in $fileName. subInFile: $subInFile | subIndex: $subIndex")
-        raiseCase.open(config, lookupRequest, responseBody) match {
+        raiseCase.open(config, lookupRequest, result) match {
           case \/-(_) =>
             logger.info("Successfully raised Salesforce case")
-            LookupResponse(200, responseBodyAsString(responseBody))
+            LookupResponse(200, responseBodyAsString(LookupResponseBody(result.fileChecked, result.subscriptionInFile)))
           case -\/(error) =>
             logger.error(error)
             LookupResponse(500, error)

--- a/src/main/scala/com/gu/fulfilmentLookup/ResponseModels.scala
+++ b/src/main/scala/com/gu/fulfilmentLookup/ResponseModels.scala
@@ -2,7 +2,7 @@ package com.gu.fulfilmentLookup
 
 import play.api.libs.json.{ JsValue, Json, Writes }
 
-case class LookupResponseBody(fileChecked: String, subscriptionInFile: Boolean, addressDetails: Option[String])
+case class LookupResponseBody(fileChecked: String, subscriptionInFile: Boolean)
 
 case class LookupResponse(statusCode: Int = 200, body: String)
 
@@ -11,8 +11,7 @@ object ResponseWriters {
   implicit val lookupResponseBodyWrites = new Writes[LookupResponseBody] {
     def writes(lookupResponseBody: LookupResponseBody): JsValue = Json.obj(
       "fileChecked" -> lookupResponseBody.fileChecked,
-      "subscriptionInFile" -> lookupResponseBody.subscriptionInFile,
-      "addressDetails" -> lookupResponseBody.addressDetails
+      "subscriptionInFile" -> lookupResponseBody.subscriptionInFile
     )
   }
 


### PR DESCRIPTION
The PII contained in this response is no longer used by clients of the API, so we should remove it.

