### PR TITLE
 Bump jackson-databind, jackson-core and jackson-annotations to 2.9.7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,9 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.0.5" % "test",
   "org.scalaz" % "scalaz-core_2.12" % "7.2.21",
   "org.mockito" % "mockito-core" % "2.18.0" % "test",
-  "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.5"
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.7",
+  "com.fasterxml.jackson.core" % "jackson-core" % "2.9.7",
+  "com.fasterxml.jackson.core" % "jackson-annotations" % "2.9.7"
 )
 
 initialize := {


### PR DESCRIPTION
https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-31507

We are pulling in old versions of jackson-databind primarily via aws-sdks. It's suggested here that this shouldn't be a breaking change for the aws sdks.

Also upgrading jackson-annotations as in other projects it has broken when databind and annotations aren't in sync, and upgrading core for completeness.


Inspired by Snyk.