### PR TITLE
bump jackson-databind to 2.9.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
 # fulfilment-lookup
 
-Validates fulfilment information for a given subscription name
+There are fulfilment files generated daily. They contain the information about who should receive a paper for that day 
+ and where the paper should be delivered (and what subscription name that delivery corresponds to). These files are 
+ provided to our delivery partners to let them know who should receive a paper, when, and where it should go.  
+
+When a customer does not receive their paper as expected, it is useful to know if we included them in this file or not. 
+This lambda checks, given a subscription name and a date, if there is an entry in the fulfilment file for that date.
+Then, it automatically creates a salesforce case to indicate a delivery problem. 
+
+#### What calls this lambda?
+
+Imagine you are a paper subscriber, and your paper fails to arrive. You can then logon to 
+`https://subscribe.theguardian.com/manage`
+
+scroll down the page and see this (highlighted below) 'report a delivery problem' section
+
+![image](https://user-images.githubusercontent.com/3072877/50844648-1403e380-1363-11e9-8000-d649e7955f09.png)
+
+Specifying the date calls the lambda with your subscription name and the date your paper didn't arrive. This 
+automatically raises a salesforce case to report your delivery problem and includes information about whether 
+there is an entry for your subscription for that date in the fulfilment file for that day. 

--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,8 @@ riffRaffUploadArtifactBucket := Option("riffraff-artifact")
 riffRaffUploadManifestBucket := Option("riffraff-builds")
 riffRaffManifestProjectName := "MemSub::Membership Admin::Fulfilment Lookup"
 
+val jacksonVersion = "2.9.8"
+
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
   "com.amazonaws" % "aws-lambda-java-log4j" % "1.0.0",
@@ -34,9 +36,9 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.0.5" % "test",
   "org.scalaz" % "scalaz-core_2.12" % "7.2.21",
   "org.mockito" % "mockito-core" % "2.18.0" % "test",
-  "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.7",
-  "com.fasterxml.jackson.core" % "jackson-core" % "2.9.7",
-  "com.fasterxml.jackson.core" % "jackson-annotations" % "2.9.7"
+  "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
+  "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
+  "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion
 )
 
 initialize := {


### PR DESCRIPTION
Here we go again. 
https://app.snyk.io/org/the-guardian-cuu/project/993ad67b-57da-4ce9-856d-a21d5d63566a/

Same deal as here:
https://github.com/guardian/fulfilment-lookup/pull/19

+ a README update


