### PR TITLE
Add more Jackson version overrides

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,7 @@ libraryDependencies ++= Seq(
   "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
   "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % jacksonVersion,
   "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonVersion,
-  "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion,
+  "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion
 )
 
 initialize := {

--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,10 @@ libraryDependencies ++= Seq(
   "org.mockito" % "mockito-core" % "2.18.0" % "test",
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
   "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
-  "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion
+  "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
+  "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % jacksonVersion,
+  "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonVersion,
+  "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion,
 )
 
 initialize := {


### PR DESCRIPTION
I'm hoping this is going to get rid of this Snyk vulnerability: https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONDATATYPE-173759