### PR TITLE
Upgrade jackson databind version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.0.5" % "test",
   "org.scalaz" % "scalaz-core_2.12" % "7.2.21",
   "org.mockito" % "mockito-core" % "2.18.0" % "test",
-  "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.9.1",
   "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
   "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
   "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % jacksonVersion,


### PR DESCRIPTION
This update is needed because snyk has flagged a vulnerability in the existing version
https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-450917