### PR TITLE
Migrate Java runtime to Corretto

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -79,7 +79,7 @@ Resources:
           Fn::GetAtt:
           - FulfilmentExecutionRole
           - Arn
-      Runtime: java8
+      Runtime: java8.al2
       Timeout: 60
     DependsOn:
     - FulfilmentExecutionRole


### PR DESCRIPTION
All Java 8 runtimes will soon be automatically implicitly migrated to Corretto so better to do it explicitly first.