### PR TITLE
Export cloudformation template for Riffraff use

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,7 @@ riffRaffPackageType := assembly.value
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")
 riffRaffUploadManifestBucket := Option("riffraff-builds")
 riffRaffManifestProjectName := "MemSub::Membership Admin::Fulfilment Lookup"
+riffRaffArtifactResources += (file("cloudformation.yaml"), "cfn/cfn.yaml")
 
 val jacksonVersion = "2.10.2"
 


### PR DESCRIPTION
This change will mean Teamcity will export the cloudformation template as part of the build process so that it can later be used in a Riffraff deploy.