### PR TITLE
Include cloudformation stack update in deployment

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -3,6 +3,14 @@ stacks:
 regions:
 - eu-west-1
 deployments:
+  cfn:
+    type: cloud-formation
+    parameters:
+      templatePath: cfn.yaml
+      cloudFormationStackName: fulfilment-lookup
+      cloudFormationStackByTags: false
+      prependStackToCloudFormationStackName: false
+      createStackIfAbsent: false 
   fulfilment-lookup:
     type: aws-lambda
     parameters:
@@ -10,3 +18,4 @@ deployments:
       bucket: fulfilment-lookup-dist
       prefixStack: false
       functionNames: [fulfilment-lookup-]
+    dependencies: [cfn]


### PR DESCRIPTION
When doing a Riffraff deploy, include any stack updates from the cloudformation template.