### PR TITLE
Bump log4j from 2.11.0 to 2.15.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ libraryDependencies ++= Seq(
   "com.github.melrief" %% "purecsv" % "0.1.1",
   "com.squareup.okhttp3" % "okhttp" % "3.10.0",
   "com.typesafe.play" %% "play-json" % "2.9.2",
-  "org.apache.logging.log4j" % "log4j-core" % "2.11.0",
+  "org.apache.logging.log4j" % "log4j-core" % "2.15.0",
   "org.scalatest" %% "scalatest" % "3.0.5" % "test",
   "org.scalaz" % "scalaz-core_2.12" % "7.2.21",
   "org.mockito" % "mockito-core" % "2.18.0" % "test",


### PR DESCRIPTION
To avoid a vulnerability.
